### PR TITLE
[herd] Fix semantics for SVE gather load instructions

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -351,7 +351,7 @@ val same_instance : event -> event -> bool
   val data_input_union : (* input to both structures *)
     event_structure -> event_structure -> event_structure option
 
-  val data_to_output : (* inut to second es output *)
+  val data_to_output : (* input to second es output *)
     event_structure -> event_structure -> event_structure option
 
   val data_to_minimals : (* second es entries are minimal evts all iico *)


### PR DESCRIPTION
For `herd/tests/instructions/AArch64.sve/V16.litmus`, before:

<img width="1084" alt="Screenshot 2024-09-15 at 17 17 02" src="https://github.com/user-attachments/assets/504033a3-f3ea-427b-9283-a4a280844a30">

after:

<img width="1179" alt="Screenshot 2024-09-15 at 17 15 26" src="https://github.com/user-attachments/assets/59572108-c8e8-44ce-ad70-9469c37485c3">
